### PR TITLE
Generate OpenSSH format keys for builder_key

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -72,13 +72,24 @@ module DeliveryCluster
       "#{node['delivery-cluster']['builders']['hostname_prefix']}-#{index}"
     end
 
-    # Generate or load an existing RSA keypair
+    # Generate or load an existing SSH RSA private key
     def builder_key
-      if File.exists?("#{tmp_infra_dir}/builder_key")
-        OpenSSL::PKey::RSA.new(File.read("#{tmp_infra_dir}/builder_key"))
-      else
-        OpenSSL::PKey::RSA.generate(2048)
+      unless File.exists?("#{tmp_infra_dir}/builder_key")
+        gen_builder_key
       end
+      IO.read("#{tmp_infra_dir}/builder_key")
+    end
+
+    # Generate or load an existing SSH RSA public key
+    def builder_key_pub
+      unless File.exists?("#{tmp_infra_dir}/builder_key.pub")
+        gen_builder_key
+      end
+      IO.read("#{tmp_infra_dir}/builder_key.pub")
+    end
+
+    def gen_builder_key
+      system("ssh-keygen -t rsa -f #{tmp_infra_dir}/builder_key -P ''")
     end
 
     # Generate or load an existing encrypted data bag secret

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -96,17 +96,16 @@ file "#{tmp_infra_dir}/encrypted_data_bag_secret" do
   action :create
 end
 
-# create required builder keys
 file "#{tmp_infra_dir}/builder_key.pub" do
   mode    '0644'
-  content builder_key.public_key.to_s
+  content builder_key_pub
   sensitive true
   action :create
 end
 
 file "#{tmp_infra_dir}/builder_key" do
   mode    '0600'
-  content builder_key.to_pem.to_s
+  content builder_key
   sensitive true
   action :create
 end
@@ -118,7 +117,7 @@ end
 
 chef_data_bag_item "keys/delivery_builder_keys" do
   raw_data(
-    builder_key:  builder_key.to_pem.to_s,
+    builder_key:  builder_key,
     delivery_pem: "#{tmp_infra_dir}/delivery.pem"
   )
   secret_path "#{tmp_infra_dir}/encrypted_data_bag_secret"
@@ -202,7 +201,7 @@ machine_file 'delivery-server-cert' do
   action :download
 end
 
-# Create the default Delivery enterprise
+# Create the default Delivery enterprise
 machine_execute "Creating Enterprise" do
   command <<-EOM.gsub(/\s+/, " ").strip!
     #{delivery_ctl} list-enterprises | grep -w ^#{node['delivery-cluster']['delivery']['enterprise']};


### PR DESCRIPTION
We can patch Delivery to support the X509 SPKI key format, but for now,
let's generate ssh style.
