### PR TITLE
Implement ssh-pub-key-file for enterprise-ctl command

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -158,6 +158,18 @@ module DeliveryCluster
       delivery_attributes
     end
 
+    def delivery_enterprise_cmd
+      # We have introduced an additional constrain to the enterprise_ctl
+      # command that require to specify --ssh-pub-key-file param starting
+      # from the Delivery Version 0.2.52
+      cmd = <<-CMD.gsub(/\s+/, " ").strip!
+        #{delivery_ctl} list-enterprises | grep -w ^#{node['delivery-cluster']['delivery']['enterprise']};
+        [ $? -ne 0 ] && #{delivery_ctl} create-enterprise #{node['delivery-cluster']['delivery']['enterprise']}
+      CMD
+      cmd << ' --ssh-pub-key-file=/etc/delivery/builder_key.pub' if Gem::Version.new(delivery_server_version) < Gem::Version.new('0.2.52')
+      cmd << " > /tmp/#{node['delivery-cluster']['delivery']['enterprise']}.creds || echo 1"
+    end
+
     def delivery_artifact
       # If we don't have the artifact, we will get it from artifactory
       # We will need VPN to do so. Or other way could be to upload it

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -2,6 +2,8 @@
 # Cookbook Name:: delivery-cluster
 # Recipe:: setup
 #
+# Author:: Salim Afiune (<afiune@chef.io>)
+#
 # Copyright 2015, Chef Software, Inc.
 #
 # All rights reserved - Do Not Redistribute
@@ -198,10 +200,7 @@ end
 
 # Create the default Delivery enterprise
 machine_execute "Creating Enterprise" do
-  command <<-EOM.gsub(/\s+/, " ").strip!
-    #{delivery_ctl} list-enterprises | grep -w ^#{node['delivery-cluster']['delivery']['enterprise']};
-    [ $? -ne 0 ] && #{delivery_ctl} create-enterprise #{node['delivery-cluster']['delivery']['enterprise']} > /tmp/#{node['delivery-cluster']['delivery']['enterprise']}.creds || echo 1
-  EOM
+  command delivery_enterprise_cmd
   machine delivery_server_hostname
 end
 


### PR DESCRIPTION
We have introduced an additional constrain to the `enterprise_ctl` command that require to specify `--ssh-pub-key-file` param starting from the Delivery Version `0.2.52`

This PR will identify when the Delivery version is grater than the version we mentioned and apply the required parameter to be able to create the default enterprise. Otherwise it will fail and you will not have a Delivery Enterprise ready to hack-in.

/cc @schisamo 
