### PR TITLE
Fix lazy attribute on `machine_execute` resource

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -201,7 +201,7 @@ end
 # Create the default Delivery enterprise
 machine_execute "Creating Enterprise" do
   chef_server lazy { chef_server_config }
-  command delivery_enterprise_cmd
+  command lazy { delivery_enterprise_cmd }
   machine delivery_server_hostname
 end
 


### PR DESCRIPTION
As my implementation depends on the `delivery version`, I need to set the `delivery_enterprise_cmd` in `lazy` mode. This PR fixes that! 
