### PR TITLE
Fixing issue with the delivery_pem key

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -114,7 +114,7 @@ chef_data_bag_item "keys/delivery_builder_keys" do
   chef_server lazy { chef_server_config }
   raw_data(
     builder_key:  builder_private_key,
-    delivery_pem: "#{tmp_infra_dir}/delivery.pem"
+    delivery_pem: File.read("#{tmp_infra_dir}/delivery.pem")
   )
   secret_path "#{tmp_infra_dir}/encrypted_data_bag_secret"
   encryption_version 1


### PR DESCRIPTION
This PR fixes the problem that instead of saving the content we was saving the path: https://github.com/opscode-cookbooks/delivery-cluster/commit/961fdaf9f7f58ae0f043050a1a797f75b0863936#diff-90d64df7f8de4e34da7678673b4eed51R122

cc/ @schisamo @seth 
