### PR TITLE
Configure knife.rb for easy interaction with the remote CS

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -1,4 +1,8 @@
 # This is the minimum config that is needed to let
 # the provisioning cookbook `delivery-cluster` to work
-current_dir = File.dirname(__FILE__)
-chef_repo_path "#{current_dir}/.."
+current_dir       = File.dirname(__FILE__)
+chef_repo_path    "#{current_dir}/.."
+node_name         'delivery'
+file_cache_path   File.join(current_dir, 'local-mode-cache', 'cache')
+delivery_knife    = File.join(Chef::Config[:file_cache_path], 'infra', 'knife.rb')
+Chef::Config.from_file(delivery_knife) if File.exist?(delivery_knife)


### PR DESCRIPTION
With this PR you will have the `.chef/knife.rb` customized to your delivery-cluster environment. That way you will be able to run any `knife` command directly.
This fixes https://github.com/opscode-cookbooks/delivery-cluster/issues/15

cc/ @schisamo @seth
