### PR TITLE
Ensure configured trusted certs exist on Delivery’s Chef Server

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -38,6 +38,10 @@ add_machine_options use_private_ip_for_ssh: node['delivery-cluster']['aws']['use
 # `/etc/opscode/chef-server.rb` file
 machine chef_server_hostname do
   add_machine_options bootstrap_options: { instance_type: node['delivery-cluster']['chef-server']['flavor'] } if node['delivery-cluster']['chef-server']['flavor']
+  # Transfer any trusted certs from the current CCR
+  Dir.glob("#{Chef::Config[:trusted_certs_dir]}/*.{crt,pem}").each do |cert_path|
+    file cert_path, cert_path
+  end
   action :converge
 end
 


### PR DESCRIPTION
If you are bootstrapping Delivery’s Chef Server against a real Chef Server (as opposed to Chef Zero) which is configured with a self-signed certificate the initial CCR will fail with the following error:

```
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
```

This can be remedied by simply transferring the currently configured trusted certs over to the instance before attempting a CCR.

/cc @afiune @seth 
