### PR TITLE
Avoid loading `delivery_knife` when running berks command

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -4,5 +4,9 @@ current_dir       = File.dirname(__FILE__)
 chef_repo_path    "#{current_dir}/.."
 node_name         'delivery'
 file_cache_path   File.join(current_dir, 'local-mode-cache', 'cache')
-delivery_knife    = File.join(Chef::Config[:file_cache_path], 'infra', 'knife.rb')
-Chef::Config.from_file(delivery_knife) if File.exist?(delivery_knife)
+# Berkshelf no longer depedends on Chef so we avoid using the
+# delivery_knife when running under a `berks` command.
+if defined? ::Chef::Config
+  delivery_knife    = File.join(Chef::Config[:file_cache_path], 'infra', 'knife.rb')
+  Chef::Config.from_file(delivery_knife) if File.exist?(delivery_knife)
+end


### PR DESCRIPTION
cc/ @schisamo 
