### PR TITLE
Add and `fqdn` attribute to pass it through delivery.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default['delivery-cluster']['id'] = nil
 # Specific attributes
 # => Delivery Server
 default['delivery-cluster']['delivery']['hostname']    = nil
+default['delivery-cluster']['delivery']['fqdn']        = nil
 default['delivery-cluster']['delivery']['flavor']      = 't2.medium'
 default['delivery-cluster']['delivery']['enterprise']  = 'my_enterprise'
 

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -162,7 +162,7 @@ module DeliveryCluster
         },
         'delivery' => {
           'chef_server' => chef_server_url,
-          'fqdn'        => delivery_server_ip
+          'fqdn'        => node['delivery-cluster']['delivery']['fqdn'] || delivery_server_ip
         }
       }
 


### PR DESCRIPTION
When we configure delivery with DNS we need to have a way to set this here.

cc/ @seth @schisamo 
