### PR TITLE
Fix delivery-server dependency to point to delivery repo

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -7,7 +7,8 @@ cookbook 'chef-server-12',
   branch: 'master'
 
 cookbook 'delivery-server',
-  git: 'git@github.com:opscode-cookbooks/delivery-server.git',
+  git: 'git@github.com:chef/delivery.git',
+  rel: 'cookbooks/delivery-server',
   branch: 'master'
 
 cookbook 'delivery_builder',

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,9 +6,10 @@ DEPENDENCIES
     path: .
     metadata: true
   delivery-server
-    git: git@github.com:opscode-cookbooks/delivery-server.git
-    revision: 0bdf51a23a0610f66c4d8e1544b8482c54eef7a4
+    git: git@github.com:chef/delivery.git
+    revision: bca3dce0f9480cebce9bac8e8dbae9202eeaf8c6
     branch: master
+    rel: cookbooks/delivery-server
   delivery_builder
     git: git@github.com:chef/delivery.git
     revision: bca3dce0f9480cebce9bac8e8dbae9202eeaf8c6


### PR DESCRIPTION
Now that www.github.com/opscode-cookbooks/delivery-server is gone. We need to fix the `Berksfile`dependency. :+1: 

cc/ @seth 
