### PR TITLE
Add dependency to delivery_truck and update delivery sha

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -15,3 +15,8 @@ cookbook 'delivery_builder',
   git: 'git@github.com:chef/delivery.git',
   rel: 'cookbooks/delivery_builder',
   branch: 'master'
+
+cookbook 'delivery_truck',
+  git: 'git@github.com:chef/delivery.git',
+  rel: 'cookbooks/delivery_truck',
+  branch: 'master'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -7,14 +7,19 @@ DEPENDENCIES
     metadata: true
   delivery-server
     git: git@github.com:chef/delivery.git
-    revision: bca3dce0f9480cebce9bac8e8dbae9202eeaf8c6
+    revision: 04c30652d79e772f144d3fac304a06d85d25cbb5
     branch: master
     rel: cookbooks/delivery-server
   delivery_builder
     git: git@github.com:chef/delivery.git
-    revision: bca3dce0f9480cebce9bac8e8dbae9202eeaf8c6
+    revision: 04c30652d79e772f144d3fac304a06d85d25cbb5
     branch: master
     rel: cookbooks/delivery_builder
+  delivery_truck
+    git: git@github.com:chef/delivery.git
+    revision: 04c30652d79e772f144d3fac304a06d85d25cbb5
+    branch: master
+    rel: cookbooks/delivery_truck
 
 GRAPH
   7-zip (1.0.2)
@@ -31,14 +36,16 @@ GRAPH
     chef-server-12 (>= 0.0.0)
     delivery-server (>= 0.0.0)
     delivery_builder (>= 0.0.0)
+    delivery_truck (>= 0.0.0)
     push-jobs (>= 0.0.0)
-  delivery-server (0.2.6)
+  delivery-server (0.2.7)
   delivery_builder (0.4.4)
     chef-sugar (>= 0.0.0)
     erlang (>= 0.0.0)
     git (>= 0.0.0)
     nodejs (>= 0.0.0)
     omnibus (>= 0.0.0)
+  delivery_truck (0.2.0)
   dmg (2.2.2)
   erlang (1.5.6)
     apt (>= 1.7.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,6 @@ version          '0.1.0'
 
 depends 'chef-server-12'
 depends 'delivery_builder'
+depends 'delivery_truck'
 depends 'delivery-server'
 depends 'push-jobs'


### PR DESCRIPTION
Updating delivery cookbook dependencies to the latest and adding `delivery_truck` to the list. 

cc/ @seth @tduffield @schisamo 
