### PR TITLE
WARNING: Read the commit message. Infra dir moved.

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -7,6 +7,6 @@ file_cache_path   File.join(current_dir, 'local-mode-cache', 'cache')
 # Berkshelf no longer depedends on Chef so we avoid using the
 # delivery_knife when running under a `berks` command.
 if defined? ::Chef::Config
-  delivery_knife    = File.join(Chef::Config[:file_cache_path], 'infra', 'knife.rb')
+  delivery_knife    = File.join(current_dir, 'delivery-cluster-data', 'knife.rb')
   Chef::Config.from_file(delivery_knife) if File.exist?(delivery_knife)
 end

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ nodes/
 vendor/
 .chef/local-mode-cache
 .chef/trusted_certs
+.chef/delivery-cluster-data

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -19,8 +19,8 @@ module DeliveryCluster
       Chef::Config.chef_repo_path
     end
 
-    def tmp_infra_dir
-      File.join(Chef::Config[:file_cache_path], 'infra')
+    def cluster_data_dir
+      File.join(current_dir, '.chef', 'delivery-cluster-data')
     end
 
     # We will return the right IP to use depending wheter we need to
@@ -79,8 +79,8 @@ module DeliveryCluster
 
     # Generate or load an existing RSA keypair
     def builder_keypair
-      if File.exists?("#{tmp_infra_dir}/builder_key")
-        OpenSSL::PKey::RSA.new(File.read("#{tmp_infra_dir}/builder_key"))
+      if File.exists?("#{cluster_data_dir}/builder_key")
+        OpenSSL::PKey::RSA.new(File.read("#{cluster_data_dir}/builder_key"))
       else
         OpenSSL::PKey::RSA.generate(2048)
       end
@@ -103,8 +103,8 @@ module DeliveryCluster
 
     # Generate or load an existing encrypted data bag secret
     def encrypted_data_bag_secret
-      if File.exists?("#{tmp_infra_dir}/encrypted_data_bag_secret")
-        File.read("#{tmp_infra_dir}/encrypted_data_bag_secret")
+      if File.exists?("#{cluster_data_dir}/encrypted_data_bag_secret")
+        File.read("#{cluster_data_dir}/encrypted_data_bag_secret")
       else
         # Ruby's `SecureRandom` module uses OpenSSL under the covers
         SecureRandom.base64(512)
@@ -139,7 +139,7 @@ module DeliveryCluster
         chef_server_url: chef_server_url,
         options: {
           client_name: 'delivery',
-          signing_key_filename: "#{tmp_infra_dir}/delivery.pem"
+          signing_key_filename: "#{cluster_data_dir}/delivery.pem"
         }
       }
     end
@@ -212,7 +212,7 @@ module DeliveryCluster
         }
       else
         # We will get it from artifactory
-        artifact = get_delivery_artifact(node['delivery-cluster']['delivery']['version'], delivery_server_node['platform'], delivery_server_node['platform_version'], tmp_infra_dir)
+        artifact = get_delivery_artifact(node['delivery-cluster']['delivery']['version'], delivery_server_node['platform'], delivery_server_node['platform_version'], cluster_data_dir)
 
         # Upload Artifact to Delivery Server
         machine_file = Chef::Resource::MachineFile.new("/var/tmp/#{artifact['name']}", run_context)
@@ -237,7 +237,7 @@ module DeliveryCluster
         if node['delivery-cluster']['delivery'][delivery_server_node['platform_family']] && node['delivery-cluster']['delivery']['version'] != 'latest'
           node['delivery-cluster']['delivery']['version']
         else
-          artifact = get_delivery_artifact(node['delivery-cluster']['delivery']['version'], delivery_server_node['platform'], delivery_server_node['platform_version'], tmp_infra_dir)
+          artifact = get_delivery_artifact(node['delivery-cluster']['delivery']['version'], delivery_server_node['platform'], delivery_server_node['platform_version'], cluster_data_dir)
           artifact['version']
         end
       end

--- a/recipes/destroy_builders.rb
+++ b/recipes/destroy_builders.rb
@@ -14,12 +14,12 @@ require 'chef/provisioning/aws_driver'
 with_driver 'aws'
 
 # Only if we have the credentials to destroy it
-if File.exist?("#{tmp_infra_dir}/delivery.pem")
+if File.exist?("#{cluster_data_dir}/delivery.pem")
   begin
     # Setting the new Chef Server we just created
     with_chef_server chef_server_url,
       client_name: 'delivery',
-      signing_key_filename: "#{tmp_infra_dir}/delivery.pem"
+      signing_key_filename: "#{cluster_data_dir}/delivery.pem"
 
     # Destroy Build Nodes
     machine_batch 'Destroying Build Nodes' do

--- a/recipes/destroy_delivery.rb
+++ b/recipes/destroy_delivery.rb
@@ -14,12 +14,12 @@ require 'chef/provisioning/aws_driver'
 with_driver 'aws'
 
 # Only if we have the credentials to destroy it
-if File.exist?("#{tmp_infra_dir}/delivery.pem")
+if File.exist?("#{cluster_data_dir}/delivery.pem")
   begin
     # Setting the new Chef Server we just created
     with_chef_server chef_server_url,
       client_name: 'delivery',
-      signing_key_filename: "#{tmp_infra_dir}/delivery.pem"
+      signing_key_filename: "#{cluster_data_dir}/delivery.pem"
 
     # Destroy Delivery Server
     machine delivery_server_hostname do
@@ -29,13 +29,13 @@ if File.exist?("#{tmp_infra_dir}/delivery.pem")
     # Delivery is gone. Why do we need the keys?
     # => Org & Delivery User Keys
     execute 'Deleting Delivery User Keys' do
-      command "rm -rf #{tmp_infra_dir}/delivery.pem"
+      command "rm -rf #{cluster_data_dir}/delivery.pem"
       action :run
     end
 
     # => Enterprise Creds
     execute 'Deleting Validator & Delivery User Keys' do
-      command "rm -rf #{tmp_infra_dir}/#{node['delivery-cluster']['delivery']['enterprise']}.creds"
+      command "rm -rf #{cluster_data_dir}/#{node['delivery-cluster']['delivery']['enterprise']}.creds"
       action :run
     end
   rescue Exception => e

--- a/recipes/destroy_keys.rb
+++ b/recipes/destroy_keys.rb
@@ -17,7 +17,7 @@
    delivery.pem
    #{node['delivery-cluster']['delivery']['enterprise']}.creds
 ).each do |file|
-  file File.join(tmp_infra_dir, file) do
+  file File.join(cluster_data_dir, file) do
     action :delete
   end
 end


### PR DESCRIPTION
As we do not have a way to force the update/sync of the cookbook with chef-provisioning we want to move the `infra/i` directory out from `.chef/local-mode-cache/cache/infra/` so we can sync the cookbook with just clearing the cache `rm -rf .chef/local-mode-cachei` and running `chef-client -z` again without any harm of loosing Delivery/Chef Server Data.

We are put it besides the trusted_certs directory. (.chef/infra)

WARNING: This will break existing implementations or running environments so you have to move the infra folder before using this versioin of delivery-cluster.

Run:

```
$ cd delivery-cluster
$ cp -r .chef/local-mode-cache/cache/infra .chef/infra
```
