### PR TITLE
Recursively create cluster data directory

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -54,6 +54,7 @@ machine chef_server_hostname do
 end
 
 directory cluster_data_dir do
+  recursive true
   action :create
 end
 


### PR DESCRIPTION
We cannot guarantee the parent directory exists. For example this error
is raised when delivery-cluster is used in the context of Test Kitchen:

```
Chef::Exceptions::EnclosingDirectoryDoesNotExist
------------------------------------------------
Parent directory /tmp/kitchen/cache/.chef does not exist, cannot create /tmp/kitchen/cache/.chef/delivery-cluster-data
```

/cc @afiune 
