### PR TITLE
Allow the Artifact pass-through the delivery server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ ATTRIBUTES
 | Attribute                                         | Description                       |
 | ------------------------------------------------- | --------------------------------- |
 | `['delivery-cluster']['delivery']['version']`     | Delivery Version. See `attributes/default.rb` |
+| `['delivery-cluster']['delivery']['pass-through']` | Allow the Artifact pass-through the delivery server. Set this parameter to `false` if your delivery server does not have VPN Access. With that, the artifact will be downloaded locally and uploaded to the server.|
 | `['delivery-cluster']['delivery']['hostname']`    | Hostname of your Delivery Server. |
 | `['delivery-cluster']['delivery']['enterprise']`  | A Delivery Enterprise that it will create. |
 | `['delivery-cluster']['delivery']['fqdn']`        | The Delivery FQDN to substitute the IP Address. |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,15 @@ default['delivery-cluster']['delivery']['fqdn']        = nil
 default['delivery-cluster']['delivery']['flavor']      = 't2.medium'
 default['delivery-cluster']['delivery']['enterprise']  = 'my_enterprise'
 
+# => pass-through
+# This attribute will allow the Artifact pass-through the delivery server.
+# This feature requires that the delivery server has VPN Access.
+#
+# NOTE: If your delivery server does NOT have access to Chef VPN you have to
+# set this to `false` so it can download the artifact locally and then
+# upload it to the delivery server.
+default['delivery-cluster']['delivery']['pass-through'] = true
+
 # => LDAP config
 # => Available Attributes
 #   => ldap_hosts


### PR DESCRIPTION
Added `pass-through` parameter that will allow the Artifact pass-through the delivery server.

By default we will set this to `true` but if your delivery server does NOT have access to Chef VPN
you have to set this to `false` so that the artifact can be downloaded locally and then upload it to
the delivery server.

NOTE: This feature requires that the delivery server has VPN Access.

This commit also substitute the `md5` checksum for `sha256` that is the one
we need for the `remote_file` resource within the `delivery-server` cookbook. 
Thanks @christophermaier !!

cc/ @seth @schisamo 
