### PR TITLE
Abstract the specific configurations by providers (aws)

### DIFF
--- a/recipes/_aws_settings.rb
+++ b/recipes/_aws_settings.rb
@@ -1,0 +1,16 @@
+require 'chef/provisioning/aws_driver'
+
+with_driver 'aws'
+
+with_machine_options(
+  bootstrap_options: {
+    instance_type: node['delivery-cluster']['aws']['flavor'],
+    key_name: node['delivery-cluster']['aws']['key_name'],
+    security_group_ids: node['delivery-cluster']['aws']['security_group_ids']
+  },
+  ssh_username: node['delivery-cluster']['aws']['ssh_username'],
+  image_id:     node['delivery-cluster']['aws']['image_id']
+)
+
+add_machine_options bootstrap_options: { subnet_id: node['delivery-cluster']['aws']['subnet_id'] } if node['delivery-cluster']['aws']['subnet_id']
+add_machine_options use_private_ip_for_ssh: node['delivery-cluster']['aws']['use_private_ip_for_ssh'] if node['delivery-cluster']['aws']['use_private_ip_for_ssh']

--- a/recipes/destroy_builders.rb
+++ b/recipes/destroy_builders.rb
@@ -9,9 +9,8 @@
 # All rights reserved - Do Not Redistribute
 #
 
-require 'chef/provisioning/aws_driver'
-
-with_driver 'aws'
+# Starting to abstract the specific configurations by providers
+include_recipe 'delivery-cluster::_aws_settings'
 
 # Only if we have the credentials to destroy it
 if File.exist?("#{cluster_data_dir}/delivery.pem")

--- a/recipes/destroy_chef_server.rb
+++ b/recipes/destroy_chef_server.rb
@@ -9,9 +9,8 @@
 # All rights reserved - Do Not Redistribute
 #
 
-require 'chef/provisioning/aws_driver'
-
-with_driver 'aws'
+# Starting to abstract the specific configurations by providers
+include_recipe 'delivery-cluster::_aws_settings'
 
 # Setting the chef-zero process
 with_chef_server Chef::Config.chef_server_url

--- a/recipes/destroy_delivery.rb
+++ b/recipes/destroy_delivery.rb
@@ -9,9 +9,8 @@
 # All rights reserved - Do Not Redistribute
 #
 
-require 'chef/provisioning/aws_driver'
-
-with_driver 'aws'
+# Starting to abstract the specific configurations by providers
+include_recipe 'delivery-cluster::_aws_settings'
 
 # Only if we have the credentials to destroy it
 if File.exist?("#{cluster_data_dir}/delivery.pem")

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -9,22 +9,11 @@
 # All rights reserved - Do Not Redistribute
 #
 
-require 'chef/provisioning/aws_driver'
-
-with_driver 'aws'
-
-with_machine_options(
-  bootstrap_options: {
-    instance_type: node['delivery-cluster']['aws']['flavor'],
-    key_name: node['delivery-cluster']['aws']['key_name'],
-    security_group_ids: node['delivery-cluster']['aws']['security_group_ids']
-  },
-  ssh_username: node['delivery-cluster']['aws']['ssh_username'],
-  image_id:     node['delivery-cluster']['aws']['image_id']
-)
-
-add_machine_options bootstrap_options: { subnet_id: node['delivery-cluster']['aws']['subnet_id'] } if node['delivery-cluster']['aws']['subnet_id']
-add_machine_options use_private_ip_for_ssh: node['delivery-cluster']['aws']['use_private_ip_for_ssh'] if node['delivery-cluster']['aws']['use_private_ip_for_ssh']
+# Starting to abstract the specific configurations by providers
+#
+# This is also useful when other cookbooks depend on `delivery-cluster`
+# and they need to configure the same set of settings. e.g. (delivery-demo)
+include_recipe 'delivery-cluster::_aws_settings'
 
 ################################################################################
 # Phase 1: Bootstrap a Chef Server instance with Chef-Zero


### PR DESCRIPTION
There will be a time where we are going to be able to provision `delivery-cluster`
in different providers. This is the starting poing to do so. Abstracting the settings
will let us manage them separate from the actual machine resources.

This is also useful when other cookbooks depend on `delivery-cluster`
and they need to configure the same set of settings. e.g. (delivery-demo)

cc/ @seth @schisamo @jonsmorrow 
