### PR TITLE
Provision an Analytics Server [OPTIONAL]

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -10,3 +10,4 @@ if defined? ::Chef::Config
   delivery_knife    = File.join(current_dir, 'delivery-cluster-data', 'knife.rb')
   Chef::Config.from_file(delivery_knife) if File.exist?(delivery_knife)
 end
+cookbook_path "#{current_dir}/../cookbooks"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .kitchen/
-clients/
+clients*
 cookbooks/
 data_bags/
-environments/
-nodes/
+environments*
+nodes*
 vendor/
 .chef/local-mode-cache
 .chef/trusted_certs

--- a/Berksfile
+++ b/Berksfile
@@ -6,6 +6,10 @@ cookbook 'chef-server-12',
   git: 'git@github.com:opscode-cookbooks/chef-server-12.git',
   branch: 'master'
 
+cookbook 'chef-server-ingredient',
+  git: 'git@github.com:opscode-cookbooks/chef-server-ingredient.git',
+  branch: 'master'
+
 cookbook 'delivery-server',
   git: 'git@github.com:chef/delivery.git',
   rel: 'cookbooks/delivery-server',

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,7 +1,11 @@
 DEPENDENCIES
   chef-server-12
     git: git@github.com:opscode-cookbooks/chef-server-12.git
-    revision: 6d2088e4ddeb241f4c9e60b3fabb743c28641fa4
+    revision: c6704284b8b3ce4cbe1e521447ddbb4192e3b4c3
+    branch: master
+  chef-server-ingredient
+    git: git@github.com:opscode-cookbooks/chef-server-ingredient.git
+    revision: 4e47b1192399a7fb3762e5f8f29d08a8dd051118
     branch: master
   delivery-cluster
     path: .
@@ -13,7 +17,7 @@ DEPENDENCIES
     rel: cookbooks/delivery-server
   delivery_builder
     git: git@github.com:chef/delivery.git
-    revision: ce7fd598e2ac351656d133dfd4e6e2e658a3281f
+    revision: f95229f8240b92a968c70c6ef7d5955f2eb2a5b2
     branch: master
     rel: cookbooks/delivery_builder
 
@@ -25,23 +29,26 @@ GRAPH
     7-zip (>= 0.0.0)
     windows (>= 0.0.0)
   build-essential (2.1.3)
-  chef-server-12 (0.1.2)
+  chef-server-12 (0.1.3)
+  chef-server-ingredient (0.2.0)
+    packagecloud (>= 0.0.0)
   chef-sugar (2.5.0)
   chef_handler (1.1.6)
   delivery-cluster (0.1.0)
     chef-server-12 (>= 0.0.0)
+    chef-server-ingredient (>= 0.0.0)
     delivery-server (>= 0.0.0)
     delivery_builder (>= 0.0.0)
     push-jobs (>= 0.0.0)
   delivery-server (0.2.11)
-  delivery_builder (0.4.7)
+  delivery_builder (0.4.14)
     chef-sugar (>= 0.0.0)
     erlang (>= 0.0.0)
     git (>= 0.0.0)
     nodejs (>= 0.0.0)
     omnibus (>= 0.0.0)
   dmg (2.2.2)
-  erlang (1.5.6)
+  erlang (1.5.7)
     apt (>= 1.7.0)
     build-essential (>= 0.0.0)
     yum (~> 3.0)
@@ -61,13 +68,14 @@ GRAPH
     ark (>= 0.0.0)
     build-essential (>= 0.0.0)
     yum-epel (>= 0.0.0)
-  omnibus (2.5.2)
+  omnibus (2.5.5)
     7-zip (~> 1.0)
     build-essential (~> 2.0)
     chef-sugar (~> 2.0)
     homebrew (~> 1.9)
     windows (~> 1.30)
     wix (~> 1.1)
+  packagecloud (0.0.17)
   push-jobs (2.2.0)
     runit (>= 0.0.0)
     windows (>= 0.0.0)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You also need to create a `security_group` with the following ports open
 | 443            | TCP | HTTP Secure
 | 22             | TCP | SSH
 | 80             | TCP | HTTP
+| 5672           | TCP | Analytics MQ
+| 10012 - 10013  | TCP | Analytics Messages/Notifier
 
 ATTRIBUTES
 ------------
@@ -54,6 +56,14 @@ ATTRIBUTES
 | `['delivery-cluster']['chef-server']['hostname']`      | Hostname of your Chef Server.     |
 | `['delivery-cluster']['chef-server']['organization']`  | The organization name we will create for the Delivery Environment. |
 | `['delivery-cluster']['chef-server']['flavor']`        | AWS Flavor of the Chef Server.   |
+
+### Analytics Settings (Not required)
+
+| Attribute                                              | Description                       |
+| ------------------------------------------------------ | --------------------------------- |
+| `['delivery-cluster']['analytics']['hostname']`      | Hostname of your Analytics Server.     |
+| `['delivery-cluster']['analytics']['fqdn']`          | The Analytics FQDN to use for the `/etc/opscode-analytics/opscode-analytics.rb`. |
+| `['delivery-cluster']['analytics']['flavor']`        | AWS Flavor of the Analytics Server.   |
 
 ### Delivery Server Settings
 
@@ -112,6 +122,7 @@ $ cat environments/test.json
   "chef_type": "environment",
   "override_attributes": {
     "delivery-cluster": {
+      "id": "my_uniq_id",
       "aws": {
         "key_name": "delivery-test",
         "ssh_username": "ubuntu",
@@ -121,13 +132,20 @@ $ cat environments/test.json
         "use_private_ip_for_ssh": true
       },
       "delivery": {
-        "flavor":"c3.xlarge"
+        "flavor": "c3.xlarge",
+        "enterprise": "my_enterprise",
+        "version": "latest"
       },
       "chef-server": {
-        "flavor":"c3.xlarge"
+        "flavor": "c3.xlarge",
+        "organization": "my_organization"
+      },
+      "analytics": {
+        "flavor": "c3.xlarge"
       },
       "builders": {
-        "flavor": "c3.large"
+        "flavor": "c3.large",
+        "count": 3
       }
     }
   }
@@ -139,6 +157,15 @@ $ cat environments/test.json
 ```
 $ bundle exec chef-client -z -o delivery-cluster::setup -E test
 ```
+
+Activate Analytics Server
+========
+In order to activate Analytics you MUST provision the entire `delivery-cluster::setup` first. After you are done completely you can execute a second `chef-zero` like:
+```
+$ bundle exec chef-client -z -o delivery-cluster::setup_analytics -E test
+```
+
+That will provision and activate Analytics on your entire cluster.
 
 UPGRADE
 ========

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,7 +82,16 @@ default['delivery-cluster']['delivery']['version'] = 'latest'
 # => Chef Server
 default['delivery-cluster']['chef-server']['hostname']     = nil
 default['delivery-cluster']['chef-server']['organization'] = 'my_enterprise'
-default['delivery-cluster']['chef-server']['flavor']       = 't2.small'
+default['delivery-cluster']['chef-server']['flavor']       = 't2.medium'
+
+# => Analytics Server (Not Required)
+#
+# In order to provision an Analytics Server you have to first provision the entire
+# `delivery-cluster::setup` after that, you are ready to run `delivery-cluster::setup_analytics`
+# that will activate analytics.
+default['delivery-cluster']['analytics']['hostname']  = nil
+default['delivery-cluster']['analytics']['fqdn']      = nil
+default['delivery-cluster']['analytics']['flavor']    = 't2.medium'
 
 # => Build Nodes
 default['delivery-cluster']['builders']['hostname_prefix']     = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,7 @@ long_description 'Installs/Configures the components of Hosted Chef Delivery'
 version          '0.1.0'
 
 depends 'chef-server-12'
+depends 'chef-server-ingredient'
 depends 'delivery_builder'
 depends 'delivery-server'
 depends 'push-jobs'

--- a/recipes/analytics.rb
+++ b/recipes/analytics.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: chef-server-cluster
+# Recipes:: analytics
+#
+# Copyright (C) 2014, Chef Software, Inc. <legal@getchef.com>
+#
+
+directory '/etc/opscode' do
+  recursive true
+end
+
+directory '/etc/opscode-analytics' do
+  recursive true
+end
+
+file '/etc/opscode-analytics/opscode-analytics.rb' do
+  content "topology 'standalone'\nanalytics_fqdn '#{node['delivery-cluster']['analytics']['fqdn']}'"
+  notifies :reconfigure, 'chef_server_ingredient[opscode-analytics]'
+end
+
+chef_server_ingredient 'opscode-analytics' do
+  notifies :reconfigure, 'chef_server_ingredient[opscode-analytics]'
+end

--- a/recipes/destroy_analytics.rb
+++ b/recipes/destroy_analytics.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: delivery-cluster
+# Recipe:: destroy_analytics
+#
+# Author:: Salim Afiune (<afiune@chef.io>)
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# All rights reserved - Do Not Redistribute
+#
+
+include_recipe 'delivery-cluster::_aws_settings'
+
+# If Analytics is enabled
+if is_analytics_enabled?
+  begin
+    # Setting the new Chef Server we just created
+    with_chef_server chef_server_url,
+      client_name: 'delivery',
+      signing_key_filename: "#{cluster_data_dir}/delivery.pem"
+
+    # Destroy Analytics Server
+    machine analytics_server_hostname do
+      action :destroy
+    end
+
+    # Delete the lock file
+    File.delete(analytics_lock_file)
+  rescue Exception => e
+    Chef::Log.warn("We can't proceed to destroy the Analytics Server.")
+    Chef::Log.warn("We couldn't get the chef-server Public IP: #{e.message}")
+  end
+else
+  Chef::Log.warn("You must provision an Analytics Server before be able to")
+  Chef::Log.warn("destroy it. READ => delivery-cluster/setup_analytics.rb")
+end

--- a/recipes/setup_analytics.rb
+++ b/recipes/setup_analytics.rb
@@ -1,0 +1,61 @@
+#
+# Cookbook Name:: delivery-cluster
+# Recipe:: setup_analytics
+#
+# Author:: Salim Afiune (<afiune@chef.io>)
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# All rights reserved - Do Not Redistribute
+#
+
+include_recipe 'delivery-cluster::_aws_settings'
+
+# This recipe assumes that you have already provisioned the
+# entire `delivery-cluster` before running it.
+machine analytics_server_hostname do
+  chef_server lazy { chef_server_config }
+  add_machine_options bootstrap_options: { instance_type: node['delivery-cluster']['analytics']['flavor']  } if node['delivery-cluster']['analytics']['flavor']
+  files lazy {{
+    "/etc/chef/trusted_certs/#{chef_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt"
+  }}
+  action :converge
+end
+
+# Activate Analytics
+activate_analytics
+
+# Configuring Analytics on the Chef Server
+machine chef_server_hostname do
+  recipe "chef-server-12::analytics"
+  attributes lazy { chef_server_attributes }
+  converge true
+  action :converge
+end
+
+%w{ actions-source.json webui_priv.pem }.each do |analytics_file|
+  machine_file "/etc/opscode-analytics/#{analytics_file}" do
+    machine chef_server_hostname
+    local_path "#{cluster_data_dir}/#{analytics_file}"
+    action :download
+  end
+end
+
+# Installing Analytics
+machine analytics_server_hostname do
+  chef_server lazy { chef_server_config }
+  recipe "delivery-cluster::analytics"
+  files(
+    '/etc/opscode-analytics/actions-source.json' => "#{cluster_data_dir}/actions-source.json",
+    '/etc/opscode-analytics/webui_priv.pem' => "#{cluster_data_dir}/webui_priv.pem"
+  )
+  attributes lazy {{
+    'delivery-cluster' => {
+      'analytics' => {
+        'fqdn' => analytics_server_ip
+      }
+    }
+  }}
+  converge true
+  action :converge
+end


### PR DESCRIPTION
It is super awesome that you can provion an Analytics Server linked to your Delivery-Cluster,
well this commit enables that!

Now you can stand and activate an Analytics Server by simply running:

```
$ bundle exec chef-client -z -o delivery-cluster::setup_analytics -E test
```

NOTE: You MUST provision the entire `delivery-cluster::setup` first.

cc/ @alex-ethier @seth @schisamo 
