### PR TITLE
Updating Chef-Server Cookbook

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,7 +1,7 @@
 DEPENDENCIES
   chef-server-12
     git: git@github.com:opscode-cookbooks/chef-server-12.git
-    revision: c6704284b8b3ce4cbe1e521447ddbb4192e3b4c3
+    revision: 47efcb18234db759123f328b737e30cb749a85b3
     branch: master
   chef-server-ingredient
     git: git@github.com:opscode-cookbooks/chef-server-ingredient.git
@@ -30,6 +30,7 @@ GRAPH
     windows (>= 0.0.0)
   build-essential (2.1.3)
   chef-server-12 (0.1.3)
+    chef-server-ingredient (>= 0.0.0)
   chef-server-ingredient (0.2.0)
     packagecloud (>= 0.0.0)
   chef-sugar (2.5.0)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ That includes:
 *  1 -  Chef Server 12
 *  1 -  Delivery Server
 *  N -  Build Nodes
+*  1 -  Analytics Server (Not Required)
 
 It will install the appropriate platform-specific delivery package
 and perform the initial configuration of Delivery Server.
+
+Additionally you could Activate an Analytics Server. [Optional]
 
 REQUIREMENTS
 ------------

--- a/recipes/destroy_all.rb
+++ b/recipes/destroy_all.rb
@@ -14,6 +14,9 @@
 # => Build Nodes
 include_recipe "delivery-cluster::destroy_builders"
 
+# => Analytics Server
+include_recipe "delivery-cluster::destroy_analytics"
+
 # => Delivery Server
 include_recipe "delivery-cluster::destroy_delivery"
 

--- a/recipes/destroy_delivery.rb
+++ b/recipes/destroy_delivery.rb
@@ -25,17 +25,9 @@ if File.exist?("#{cluster_data_dir}/delivery.pem")
       action :destroy
     end
 
-    # Delivery is gone. Why do we need the keys?
-    # => Org & Delivery User Keys
-    execute 'Deleting Delivery User Keys' do
-      command "rm -rf #{cluster_data_dir}/delivery.pem"
-      action :run
-    end
-
-    # => Enterprise Creds
-    execute 'Deleting Validator & Delivery User Keys' do
-      command "rm -rf #{cluster_data_dir}/#{node['delivery-cluster']['delivery']['enterprise']}.creds"
-      action :run
+    # Delete Enterprise Creds
+    file File.join(cluster_data_dir, "#{node['delivery-cluster']['delivery']['enterprise']}.creds") do
+      action :delete
     end
   rescue Exception => e
     Chef::Log.warn("We can't proceed to destroy the Delivery Server.")

--- a/recipes/setup_analytics.rb
+++ b/recipes/setup_analytics.rb
@@ -11,8 +11,14 @@
 
 include_recipe 'delivery-cluster::_aws_settings'
 
-# This recipe assumes that you have already provisioned the
-# entire `delivery-cluster` before running it.
+# There are two ways to provision the Analytics Server
+#
+# 1) Provisioning the entire `delivery-cluster::setup` or
+# 2) Just the Chef Server `delivery-cluster::setup_chef_server`
+#
+# After that you are good to provision Analytics running:
+# => # bundle exec chef-client -z -o delivery-cluster::setup_analytics -E test
+
 machine analytics_server_hostname do
   chef_server lazy { chef_server_config }
   add_machine_options bootstrap_options: { instance_type: node['delivery-cluster']['analytics']['flavor']  } if node['delivery-cluster']['analytics']['flavor']

--- a/recipes/setup_chef_server.rb
+++ b/recipes/setup_chef_server.rb
@@ -1,0 +1,92 @@
+#
+# Cookbook Name:: delivery-cluster
+# Recipe:: setup_chef_server
+#
+# Author:: Salim Afiune (<afiune@chef.io>)
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# All rights reserved - Do Not Redistribute
+#
+
+include_recipe 'delivery-cluster::_aws_settings'
+
+# It's ugly but this must happen in the compile phase so we can switch out
+# the Chef Server we are talking to for the remainder of the CCR.
+
+# Provision the Chef Server with an empty runlist so we can extract
+# it's primary ipaddress to use as the hostname in the initial
+# `/etc/opscode/chef-server.rb` file
+machine chef_server_hostname do
+  add_machine_options bootstrap_options: { instance_type: node['delivery-cluster']['chef-server']['flavor'] } if node['delivery-cluster']['chef-server']['flavor']
+  # Transfer any trusted certs from the current CCR
+  Dir.glob("#{Chef::Config[:trusted_certs_dir]}/*.{crt,pem}").each do |cert_path|
+    file cert_path, cert_path
+  end
+  action :converge
+end
+
+# Now that we've extracted the Chef Server's ipaddress we can fully
+# converge and complete the install.
+machine chef_server_hostname do
+  recipe "chef-server-12"
+  attributes lazy { chef_server_attributes }
+  converge true
+  action :converge
+end
+
+directory Chef::Config[:trusted_certs_dir] do
+  action :create
+end
+
+machine_file 'chef-server-cert' do
+  path lazy { "/var/opt/opscode/nginx/ca/#{chef_server_ip}.crt" }
+  machine chef_server_hostname
+  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt" }
+  action :download
+end
+
+directory cluster_data_dir do
+  recursive true
+  action :create
+end
+
+# Fetch our client and validator pems from the provisioned Chef Server
+machine_file "/tmp/validator.pem" do
+  machine chef_server_hostname
+  local_path "#{cluster_data_dir}/validator.pem"
+  action :download
+end
+
+machine_file "/tmp/delivery.pem" do
+  machine chef_server_hostname
+  mode "0644"                                     # This is not working.
+  local_path "#{cluster_data_dir}/delivery.pem"
+  action :download
+end
+
+# Workaround: Ensure that the `delivery.pem` has the right permissions.
+# PR: https://github.com/chef/chef-provisioning/issues/174
+file "#{cluster_data_dir}/delivery.pem" do
+  mode '0644'
+end
+
+# generate a knife config file that points at the new Chef Server
+file File.join(cluster_data_dir, 'knife.rb') do
+  content lazy {
+    <<-EOH
+node_name         'delivery'
+chef_server_url   '#{chef_server_url}'
+client_key        '#{cluster_data_dir}/delivery.pem'
+cookbook_path     '#{Chef::Config[:cookbook_path]}'
+trusted_certs_dir '#{Chef::Config[:trusted_certs_dir]}'
+    EOH
+  }
+end
+
+execute "upload delivery cookbooks" do
+  command "knife cookbook upload --all --cookbook-path #{Chef::Config[:cookbook_path]}"
+  environment(
+    'KNIFE_HOME' => cluster_data_dir
+  )
+end


### PR DESCRIPTION
This commit includes three changes:
- Upgrade the `chef-server-12` cookbook to install the latest `chef-server-core` version from package cloud using the awesome `chef-server-ingredient` cookbook.
- Separate the `chef-server` setup from the main `setup.rb` to give more modularity.
- Add the `destroy_analytics.rb` recipe to `destroy_all` to indeed destroy everything on the cluster.

Extra documentation.. :smile: 

cc/ @schisamo @seth 
