### PR TITLE
Always force upload cookbooks

### DIFF
--- a/recipes/setup_chef_server.rb
+++ b/recipes/setup_chef_server.rb
@@ -85,7 +85,7 @@ trusted_certs_dir '#{Chef::Config[:trusted_certs_dir]}'
 end
 
 execute "upload delivery cookbooks" do
-  command "knife cookbook upload --all --cookbook-path #{Chef::Config[:cookbook_path]}"
+  command "knife cookbook upload --all --cookbook-path #{Chef::Config[:cookbook_path]} --force"
   environment(
     'KNIFE_HOME' => cluster_data_dir
   )


### PR DESCRIPTION
This works around an issue where `knife cookbook upload` does not return non-zero if any cookbooks it’s attempting to upload are frozen.

Example output of `knife cookbook upload` with frozen cookbooks:
https://gist.github.com/schisamo/60427acc3cfe7a6bc056

/cc @afiune @cwebberOps 
