### PR TITLE
Use the delivery_build recipe and CLI job exec

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -15,8 +15,8 @@ cookbook 'delivery-server',
   rel: 'cookbooks/delivery-server',
   branch: 'master'
 
-cookbook 'delivery_builder',
+cookbook 'delivery_build',
   git: 'git@github.com:chef/delivery.git',
-  rel: 'cookbooks/delivery_builder',
+  rel: 'cookbooks/delivery_build',
   branch: 'master'
 

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -5,56 +5,40 @@ DEPENDENCIES
     branch: master
   chef-server-ingredient
     git: git@github.com:opscode-cookbooks/chef-server-ingredient.git
-    revision: 4e47b1192399a7fb3762e5f8f29d08a8dd051118
+    revision: 5a066b51e8a82bd4451eb77a4038d54e959b0261
     branch: master
   delivery-cluster
     path: .
     metadata: true
   delivery-server
     git: git@github.com:chef/delivery.git
-    revision: ce7fd598e2ac351656d133dfd4e6e2e658a3281f
+    revision: 9b1988b4260f3b2fcd5de72d10cf6491aafd42c1
     branch: master
     rel: cookbooks/delivery-server
-  delivery_builder
+  delivery_build
     git: git@github.com:chef/delivery.git
-    revision: f95229f8240b92a968c70c6ef7d5955f2eb2a5b2
+    revision: 9b1988b4260f3b2fcd5de72d10cf6491aafd42c1
     branch: master
-    rel: cookbooks/delivery_builder
+    rel: cookbooks/delivery_build
 
 GRAPH
-  7-zip (1.0.2)
-    windows (>= 1.2.2)
-  apt (2.6.1)
-  ark (0.9.0)
-    7-zip (>= 0.0.0)
-    windows (>= 0.0.0)
   build-essential (2.1.3)
   chef-server-12 (0.1.3)
     chef-server-ingredient (>= 0.0.0)
-  chef-server-ingredient (0.2.0)
+  chef-server-ingredient (0.3.0)
     packagecloud (>= 0.0.0)
-  chef-sugar (2.5.0)
   chef_handler (1.1.6)
   delivery-cluster (0.1.0)
     chef-server-12 (>= 0.0.0)
     chef-server-ingredient (>= 0.0.0)
     delivery-server (>= 0.0.0)
-    delivery_builder (>= 0.0.0)
+    delivery_build (>= 0.0.0)
     push-jobs (>= 0.0.0)
-  delivery-server (0.2.11)
-  delivery_builder (0.4.14)
-    chef-sugar (>= 0.0.0)
-    erlang (>= 0.0.0)
+  delivery-server (0.2.14)
+  delivery_build (0.1.2)
     git (>= 0.0.0)
-    nodejs (>= 0.0.0)
-    omnibus (>= 0.0.0)
+    packagecloud (>= 0.0.0)
   dmg (2.2.2)
-  erlang (1.5.7)
-    apt (>= 1.7.0)
-    build-essential (>= 0.0.0)
-    yum (~> 3.0)
-    yum-epel (>= 0.0.0)
-    yum-erlang_solutions (>= 0.0.0)
   git (4.1.0)
     build-essential (>= 0.0.0)
     dmg (>= 0.0.0)
@@ -62,34 +46,16 @@ GRAPH
     windows (>= 0.0.0)
     yum (~> 3.0)
     yum-epel (>= 0.0.0)
-  homebrew (1.12.0)
-    build-essential (>= 2.1.2)
-  nodejs (2.2.0)
-    apt (>= 0.0.0)
-    ark (>= 0.0.0)
-    build-essential (>= 0.0.0)
-    yum-epel (>= 0.0.0)
-  omnibus (2.5.5)
-    7-zip (~> 1.0)
-    build-essential (~> 2.0)
-    chef-sugar (~> 2.0)
-    homebrew (~> 1.9)
-    windows (~> 1.30)
-    wix (~> 1.1)
   packagecloud (0.0.17)
   push-jobs (2.2.0)
     runit (>= 0.0.0)
     windows (>= 0.0.0)
-  runit (1.5.16)
+  runit (1.5.18)
     build-essential (>= 0.0.0)
     yum (~> 3.0)
     yum-epel (>= 0.0.0)
-  windows (1.36.1)
+  windows (1.36.6)
     chef_handler (>= 0.0.0)
-  wix (1.1.0)
-    windows (>= 1.2.2)
-  yum (3.5.2)
+  yum (3.5.3)
   yum-epel (0.6.0)
-    yum (~> 3.0)
-  yum-erlang_solutions (0.2.0)
     yum (~> 3.0)

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -10,7 +10,6 @@
 #
 
 require 'openssl'
-require 'net/ssh'
 require 'fileutils'
 require 'securerandom'
 
@@ -86,26 +85,13 @@ module DeliveryCluster
       "#{node['delivery-cluster']['builders']['hostname_prefix']}-#{index}"
     end
 
-    # Generate or load an existing RSA keypair
-    def builder_keypair
-      if File.exists?("#{cluster_data_dir}/builder_key")
-        OpenSSL::PKey::RSA.new(File.read("#{cluster_data_dir}/builder_key"))
-      else
-        OpenSSL::PKey::RSA.generate(2048)
-      end
-    end
-
     def builder_private_key
-      builder_keypair.to_pem.to_s
-    end
-
-    def builder_public_key
-      "#{builder_keypair.ssh_type} #{[builder_keypair.to_blob].pack('m0')}"
+      File.read(File.join(cluster_data_dir, "builder_key"))
     end
 
     def builder_run_list
       @builder_run_list ||= begin
-        base_builder_run_list = %w( recipe[push-jobs] recipe[delivery_builder] )
+        base_builder_run_list = %w( recipe[push-jobs] recipe[delivery_build] )
         base_builder_run_list + node['delivery-cluster']['builders']['additional_run_list']
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,6 @@ version          '0.1.0'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'
-depends 'delivery_builder'
+depends 'delivery_build'
 depends 'delivery-server'
 depends 'push-jobs'

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -29,18 +29,9 @@ file "#{cluster_data_dir}/encrypted_data_bag_secret" do
 end
 
 # create required builder keys
-file "#{cluster_data_dir}/builder_key.pub" do
-  mode    '0644'
-  content builder_public_key
-  sensitive true
-  action :create
-end
-
-file "#{cluster_data_dir}/builder_key" do
-  mode    '0600'
-  content builder_private_key
-  sensitive true
-  action :create
+execute 'builder ssh key' do
+  command "ssh-keygen -t rsa -N '' -b 2048 -f #{cluster_data_dir}/builder_key"
+  not_if { File.exists?("#{cluster_data_dir}/builder_key") }
 end
 
 # create the data bag (and item) to store our builder keys


### PR DESCRIPTION
This change flips delivery-cluster to use the CLI based job execution.
- It fixes a ruby version problem with the public/private ssh key
  generation, replacing it with a call to ssh-keygen
- It changes the builder run list to be delivery_build rather than
  delivery_builder

/cc @afiune @schisamo @seth @alex-ethier 
