### PR TITLE
Enable Multiple Environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ nodes*
 vendor/
 .chef/local-mode-cache
 .chef/trusted_certs
-.chef/delivery-cluster-*
+.chef/delivery-cluster*
 .chef/keys
 .chef/provisioning/

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -29,7 +29,7 @@ module DeliveryCluster
     end
 
     def cluster_data_dir
-      File.join(current_dir, '.chef', 'delivery-cluster-data')
+      File.join(current_dir, '.chef', "delivery-cluster-data-#{delivery_cluster_id}")
     end
 
     def use_private_ip_for_ssh

--- a/recipes/_settings.rb
+++ b/recipes/_settings.rb
@@ -13,3 +13,9 @@ create_provisioning(DeliveryCluster::Provisioning.for_driver(node['delivery-clus
 with_driver provisioning.driver
 
 with_machine_options(provisioning.machine_options)
+
+# Link the actual `cluster_data_dir` to `delivery-cluster-data`
+# so that `.chef/knife.rb` knows which one is our working cluster
+link File.join(current_dir, '.chef', "delivery-cluster-data") do
+  to cluster_data_dir
+end


### PR DESCRIPTION
Before if you tried to create multiple clusters with multiple environments the
`delivery-cluster-data` will be override and you will loose the configuration of
other environments, now you will have a `delivery-cluster-data-#{cluster_id}` per
cluster and link it to the current `delivery-cluster-data`.

e.g. Multiple environments

```
salimafiune@afiuneChef:~/github/delivery-cluster
$ ls -l .chef/
total 24
lrwxr-xr-x   1 salimafiune  staff   88 Apr  7 15:36 delivery-cluster-data -> /Users/salimafiune/github/delivery-cluster/.chef/delivery-cluster-data-woomooku
drwxr-xr-x  10 salimafiune  staff  340 Apr  7 15:36 delivery-cluster-data-test
drwxr-xr-x  10 salimafiune  staff  340 Apr  7 15:36 delivery-cluster-data-woomooku
drwxr-xr-x  10 salimafiune  staff  340 Apr  7 15:36 delivery-cluster-data-chefconf
```

For running environments you need to move the existing `delivery-cluster-data`
to `delivery-cluster-data-#{cluster_id}`
