### PR TITLE
Use an existing chef-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Specific Attributes per Machine
 | `hostname`      | Hostname of your Chef Server.     |
 | `organization`  | The organization name we will create for the Delivery Environment. |
 | `flavor`        | AWS Flavor of the Chef Server.   |
+| `existing`      | Set this to `true` if you want to use an existing chef-server. |
 
 ### Delivery Server Settings
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,6 +101,7 @@ default['delivery-cluster']['delivery']['version'] = 'latest'
 default['delivery-cluster']['chef-server']['hostname']     = nil
 default['delivery-cluster']['chef-server']['organization'] = 'my_enterprise'
 default['delivery-cluster']['chef-server']['flavor']       = 't2.medium'
+default['delivery-cluster']['chef-server']['existing']     = false
 
 # => Analytics Server (Not Required)
 #

--- a/recipes/setup_chef_server.rb
+++ b/recipes/setup_chef_server.rb
@@ -31,7 +31,11 @@ end
 # Now that we've extracted the Chef Server's ipaddress we can fully
 # converge and complete the install.
 machine chef_server_hostname do
-  recipe "chef-server-12"
+  if node['delivery-cluster']['chef-server']['existing']
+    recipe "chef-server-12::delivery_setup"
+  else
+    recipe "chef-server-12"
+  end
   attributes lazy { chef_server_attributes }
   converge true
   action :converge


### PR DESCRIPTION
Customers might have an existing chef-server 12 up and running,
why not use it and just configure the delivery bits that we need.

cc/ @jonsmorrow @seth @schisamo 
