### PR TITLE
Enable Delivery FQDN

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -232,7 +232,7 @@ module DeliveryCluster
         },
         'delivery' => {
           'chef_server' => chef_server_url,
-          'fqdn'        => node['delivery-cluster']['delivery']['fqdn'] || delivery_server_ip
+          'fqdn'        => delivery_server_ip
         }
       }
 


### PR DESCRIPTION
Enables setting the Delivery FQDN for test-kitchen and other ssh setups. Needed because of [this.](https://github.com/opscode-cookbooks/delivery-cluster/blob/master/recipes/setup_delivery.rb#L156)
