### PR TITLE
Bumping delivery cookbook versions

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -15,12 +15,12 @@ DEPENDENCIES
     metadata: true
   delivery-server
     git: https://github.com/chef/delivery.git
-    revision: c710bc0b8709b12709df9d954440083a65fd5c09
+    revision: fca1a8a5856c1357826d849591f18d5e42d1b773
     branch: master
     rel: cookbooks/delivery-server
   delivery_build
     git: https://github.com/chef/delivery.git
-    revision: c710bc0b8709b12709df9d954440083a65fd5c09
+    revision: fca1a8a5856c1357826d849591f18d5e42d1b773
     branch: master
     rel: cookbooks/delivery_build
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'delivery-team@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures the components of Hosted Chef Delivery'
 long_description 'Installs/Configures the components of Hosted Chef Delivery'
-version          '0.2.0'
+version          '0.2.1'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'


### PR DESCRIPTION
Bumping delivery cookbook to pass `delivery-cli` attributes to the `delivery_build` cookbook
