### PR TITLE
Jm/cli from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Specific Attributes per Machine
 | `role`                | Name of the Delivery Build Nodes Role. |
 | `count`               | Number of Build Nodes to create. |
 | `additional_run_list` | Additional run list items to apply to build nodes. |
+| `delivery-cli`        | Optional Hash of delivery-cli attrs: `{ "version": "0.3.0", "artifact": "http://my.delivery-cli.pkg", "checksum": "123456789ABCDEF"}` |
 
 ### Analytics Settings (Not required)
 
@@ -447,3 +448,4 @@ LICENSE AND AUTHORS
 - Author: Salim Afiune (<afiune@chef.io>)
 - Author: Seth Chisamore (<schisamo@chef.io>)
 - Author: Tom Duffield (<tom@chef.io>)
+- Author: Jon Morrow (<jmorrow@chef.io>)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -136,3 +136,13 @@ default['delivery-cluster']['builders']['hostname_prefix']     = nil
 default['delivery-cluster']['builders']['count']               = 3
 default['delivery-cluster']['builders']['flavor']              = 't2.small'
 default['delivery-cluster']['builders']['additional_run_list'] = []
+
+# Optional Hash of delivery-cli
+#
+# You can specify a delivery-cli artifact passing the following attributes:
+# => { 
+#      "version":  "0.3.0",
+#      "artifact": "http://my.delivery-cli.pkg",
+#      "checksum": "123456789ABCDEF" 
+#    }
+default['delivery-cluster']['builders']['delivery-cli']        = {}

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -242,6 +242,15 @@ module DeliveryCluster
       delivery_attributes
     end
 
+    def builders_attributes
+      builders_attributes = {}
+
+      # Add cli attributes if they exists.
+      builders_attributes['delivery_build']['delivery-cli'] = node['delivery-cluster']['builders']['delivery-cli'] unless node['delivery-cluster']['builders']['delivery-cli'].empty?
+
+      builders_attributes
+    end
+
     def delivery_enterprise_cmd
       # We have introduced an additional constrain to the enterprise_ctl
       # command that require to specify --ssh-pub-key-file param starting

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'delivery-team@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures the components of Hosted Chef Delivery'
 long_description 'Installs/Configures the components of Hosted Chef Delivery'
-version          '0.2.1'
+version          '0.2.2'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'

--- a/recipes/setup_delivery.rb
+++ b/recipes/setup_delivery.rb
@@ -179,6 +179,7 @@ machine_batch "#{node['delivery-cluster']['builders']['count']}-build-nodes" do
         "/etc/chef/trusted_certs/#{delivery_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{delivery_server_ip}.crt",
         '/etc/chef/encrypted_data_bag_secret' => "#{cluster_data_dir}/encrypted_data_bag_secret"
       }}
+      attributes lazy { builders_attributes }
       converge true
       action :converge
     end


### PR DESCRIPTION
Now you can specify a `delivery-cli` artifact. That way you don't only depends on packagecloud or build the cli from source code. 

An example of the Hash you can pass is:

```
default['delivery-cluster']['builders']['delivery-cli'] = { 
      "version":  "0.3.0",
      "artifact": "http://my.delivery-cli.pkg",
      "checksum": "123456789ABCDEF" 
}
```

or if you are using an environment file:

```
{
  "name": "test",
  "description": "Test",
  "json_class": "Chef::Environment",
  "chef_type": "environment",
  "override_attributes": {
    "delivery-cluster": {
      ... <output cut > ...
      "builders": {
        "delivery-cli": { 
          "version":  "0.3.0",
          "artifact": "http://my.delivery-cli.pkg",
          "checksum": "123456789ABCDEF" 
        }
        "count": 1
      }
    }
  }
}
```
