### PR TITLE
Do not error on missing local provisioner

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -333,7 +333,7 @@ module DeliveryCluster
     # user has the necessary license file on the provisioning node before we begin.
     # This method will check for the license file in the compile phase to prevent
     # any work being done if the user doesn't even have a license.
-    def validate_license_files
+    def validate_license_file
       msg_delim = "***************************************************"
 
       contact_msg = <<-END
@@ -349,11 +349,6 @@ account representative.
       if node['delivery-cluster']['delivery']['license_file'].nil?
         raise "#{contact_msg}Please set `#{node['delivery-cluster']['delivery']['license_file']}`\n" \
               "in your environment file.\n\n#{msg_delim}"
-      end
-
-      unless File.exist?(node['delivery-cluster']['delivery']['license_file']
-        raise "#{contact_msg}License file could not be found: " \
-              "#{node['delivery-cluster']['delivery']['license_file']}\n\n#{msg_delim}"
       end
     end
   end


### PR DESCRIPTION
There may be situations where users will use Chef to pull down the
license file. This means it won't be available in the compile phase. As
such, we will trust that if the user has set the license path they know
what they are doing and will _not_ error if we can't find the license
file on the provisioner.
