### PR TITLE
The default key file is incorrect. It tries to use ~/.ssh/id_rsa.pub …

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -185,7 +185,7 @@ namespace :setup do
       loop do
         puts 'Key File Not Found'.red if options['driver']['key_file']
         options['driver']['key_file'] = ask_for('Key File',
-                                                File.expand_path('~/.ssh/id_rsa.pub'))
+                                                File.expand_path('~/.ssh/id_rsa'))
         break if File.exist?(options['driver']['key_file'])
       end
     when 'aws'


### PR DESCRIPTION
…instead of ~/.ssh/id_rsa so if someone accepts this default with the SSH driver the setup will fail.