### PR TITLE
Chowning specific files instead of recursing

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -36,7 +36,7 @@ GRAPH
   chef_handler (1.2.0)
   delivery-base (0.1.0)
     push-jobs (>= 0.0.0)
-  delivery-cluster (0.5.8)
+  delivery-cluster (0.5.9)
     apt (>= 0.0.0)
     chef-ingredient (>= 0.0.0)
     chef-server-12 (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Deployment cookbook for standing up Delivery Clusters'
 long_description 'Installs Chef Delivery, a solution for continuously ' \
                  'delivering applications and infrastructure safely at speed'
-version '0.5.8'
+version '0.5.9'
 
 depends 'chef-server-12'
 depends 'chef-ingredient'

--- a/recipes/setup_delivery_server.rb
+++ b/recipes/setup_delivery_server.rb
@@ -119,10 +119,12 @@ machine delivery_server_hostname do
 end
 
 # Set right permissions to delivery files
-machine_execute "Chown '/etc/delivery' to 'delivery' user" do
-  chef_server lazy { chef_server_config }
-  command 'chown -R delivery /etc/delivery'
-  machine delivery_server_hostname
+%w( delivery.pem builder_key builder_key.pub ).each do |file|
+  machine_execute "Chown '/etc/delivery/#{file}' to 'delivery' user" do
+    chef_server lazy { chef_server_config }
+    command "chown delivery /etc/delivery/#{file}"
+    machine delivery_server_hostname
+  end
 end
 
 machine_file 'delivery-server-cert' do


### PR DESCRIPTION
When we recursively chown'd /etc/delivery we broke logrotate for nginx.
The configuration file needs to be owned by root. This change is to
explicitly chown the files that should be owned by delivery.