### PR TITLE
set builder push_jobs ssl_verify_mode=:verify_none

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -229,3 +229,6 @@ default['delivery-cluster']['builders']['delivery-cli']        = {}
 
 # Optional ChefDK version
 default['delivery-cluster']['builders']['chefdk_version']      = nil
+
+# verify_none is required for build nodes to report in aws
+default['delivery-cluster']['builders']['push_jobs']['ssl_verify_mode'] = :verify_none

--- a/libraries/helpers_builders.rb
+++ b/libraries/helpers_builders.rb
@@ -83,6 +83,18 @@ module DeliveryCluster
           )
         end
 
+        # update ssl_verify_mode for push jobs
+        if node['delivery-cluster']['builders']['push_jobs']['ssl_verify_mode']
+          builders_attributes = Chef::Mixin::DeepMerge.hash_only_merge(
+            builders_attributes,
+            'push_jobs' => {
+              'chef' => {
+                'ssl_verify_mode' => node['delivery-cluster']['builders']['push_jobs']['ssl_verify_mode']
+              }
+            }
+          )
+        end
+
         # Add trusted_certs attributes
         builders_attributes = Chef::Mixin::DeepMerge.hash_only_merge(
           builders_attributes,


### PR DESCRIPTION
This defaults the push-jobs configuration on the builder to verify_none.