### PR TITLE
Adding support for external Elasticsearch

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -172,6 +172,9 @@ default['delivery-cluster']['insights']['rabbitmq']['port'] = '5672'
 default['delivery-cluster']['insights']['rabbitmq']['user'] = 'insights'
 default['delivery-cluster']['insights']['rabbitmq']['password'] = 'chefrocks'
 
+# Allow for external Elasticsearch nodes - nil assumes use the bundled install
+default['delivery-cluster']['delivery']['elasticsearch']['urls'] = nil
+
 # Disaster Recovery Attrs on Delivery
 default['delivery-cluster']['delivery']['disaster_recovery']['enable'] = false
 default['delivery-cluster']['delivery']['primary'] = nil

--- a/spec/unit/recipes/delivery_spec.rb
+++ b/spec/unit/recipes/delivery_spec.rb
@@ -54,4 +54,21 @@ describe 'delivery-cluster::delivery' do
         expect(content).to include("rabbitmq['port'] = '5672'")
       }
   end
+
+  context 'when external elasticsearch nodes are specified' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['delivery-cluster'] = cluster_data
+        node.set['delivery-cluster']['delivery']['insights']['enable'] = true
+        node.set['delivery-cluster']['delivery']['elasticsearch']['urls'] = ['https://es-node-1', 'https://es-node-2']
+      end.converge(described_recipe)
+    end
+
+    it 'includes the elasticsearch nodes in the delivery.rb config file' do
+      expect(chef_run).to render_file('/etc/delivery/delivery.rb')
+        .with_content { |content|
+          expect(content).to include(%{elasticsearch['urls'] = ["https://es-node-1", "https://es-node-2"]})
+        }
+    end
+  end
 end

--- a/templates/default/delivery.rb.erb
+++ b/templates/default/delivery.rb.erb
@@ -18,6 +18,9 @@ rabbitmq['exchange'] = '<%= rabbitmq['exchange'] %>'
 rabbitmq['user'] = '<%= rabbitmq['user'] %>'
 rabbitmq['password'] = '<%= rabbitmq['password'] %>'
 rabbitmq['port'] = '<%= rabbitmq['port'] %>'
+<%   if node['delivery-cluster']['delivery']['elasticsearch']['urls'] -%>
+elasticsearch['urls'] = <%= Array(node['delivery-cluster']['delivery']['elasticsearch']['urls']).to_s %>
+<%   end -%>
 <% end -%>
 
 <%= node['delivery-cluster']['delivery']['config'] if node['delivery-cluster']['delivery']['config'] -%>


### PR DESCRIPTION
Setting the following attribute:

`delivery_cluster.delivery.elasticsearch.urls`

... with an array of fully-qualified URLs will configure Insights
to use them for all appropriate systems (Logstash, Kibana, etc.)
and not use a local Elasticsearch process on the Delivery server.

Example:

```
{
  "override_attributes": {
    "delivery-cluster": {
      "delivery": {
        "insights": {
          "enable": true
        },
        "elasticsearch": {
          "urls": [
            "http://elasticsearch1.mycompany.com",
            "http://elasticsearch2.mycompany.com",
            "http://elasticsearch3.mycompany.com"
          ]
        }
      }
    }
  }
}
```